### PR TITLE
feat [CI-13676]: Updating plugin to add test parsing with quarantine.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/urfave/cli/v2 v2.25.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -23,5 +23,7 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ func main() {
 
 func run(c *cli.Context) error {
 	p := Plugin{
-		GlobPaths:         c.String(globSetting),
-		QuarantineFile:    c.String(quarantineFileSetting),
-		FailOnQuarantine:  c.Bool(quarantineSetting),
+		GlobPaths:        c.String(globSetting),
+		QuarantineFile:   c.String(quarantineFileSetting),
+		FailOnQuarantine: c.Bool(quarantineSetting),
 	}
 	return p.Exec()
 }

--- a/main.go
+++ b/main.go
@@ -8,8 +8,12 @@ import (
 )
 
 const (
-	globSetting = "test_globs"
-	globEnv     = "PLUGIN_TEST_GLOBS"
+	globSetting           = "test_globs"
+	globEnv               = "PLUGIN_TEST_GLOBS"
+	quarantineFileSetting = "quarantine_file"
+	quarantineFileEnv     = "PLUGIN_QUARANTINE_FILE"
+	quarantineSetting     = "fail_on_quarantine"
+	quarantineEnv         = "PLUGIN_FAIL_ON_QUARANTINE"
 )
 
 func main() {
@@ -22,6 +26,14 @@ func main() {
 				Name:    "test_globs",
 				EnvVars: []string{"PLUGIN_TEST_GLOBS"},
 			},
+			&cli.StringFlag{
+				Name:    "quarantine_file",
+				EnvVars: []string{"PLUGIN_QUARANTINE_FILE"},
+			},
+			&cli.BoolFlag{
+				Name:    "fail_on_quarantine",
+				EnvVars: []string{"PLUGIN_FAIL_ON_QUARANTINE"},
+			},
 		},
 	}
 	if err := app.Run(os.Args); err != nil {
@@ -31,7 +43,9 @@ func main() {
 
 func run(c *cli.Context) error {
 	p := Plugin{
-		GlobPaths: c.String(globSetting),
+		GlobPaths:         c.String(globSetting),
+		QuarantineFile:    c.String(quarantineFileSetting),
+		FailOnQuarantine:  c.Bool(quarantineSetting),
 	}
 	return p.Exec()
 }

--- a/parser.go
+++ b/parser.go
@@ -189,6 +189,7 @@ func isURL(source string) bool {
 func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interface{}, log *logrus.Logger) (TestStats, error) {
 	files := getFiles(paths, log)
 	stats := TestStats{}
+	nonQuarantinedFailures := 0
 
 	if len(files) == 0 {
 		log.Errorln("could not find any files matching the provided report path")
@@ -215,6 +216,7 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 				case "failed":
 					if !isQuarantined(testIdentifier, quarantineList) {
 						log.Infoln(fmt.Sprintf("Not Quarantined test failed: %s", testIdentifier))
+						nonQuarantinedFailures++
 					} else {
 						log.Infoln(fmt.Sprintf("Quarantined test failed: %s", testIdentifier))
 					}
@@ -223,6 +225,7 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 					fileStats.SkippedCount++
 				case "error":
 					fileStats.ErrorCount++
+					// nonQuarantinedFailures++ // Assuming errors are always considered non-quarantined
 				}
 			}
 		}
@@ -239,8 +242,8 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 
 	log.Infoln("Finished parsing tests with quarantine list")
 
-	if stats.FailCount > 0 || stats.ErrorCount > 0 {
-		return stats, fmt.Errorf("found %d non-quarantined failed tests and %d errors", stats.FailCount, stats.ErrorCount)
+	if nonQuarantinedFailures > 0 {
+		return stats, fmt.Errorf("found %d non-quarantined failed tests and errors", nonQuarantinedFailures)
 	}
 	return stats, nil
 }

--- a/parser.go
+++ b/parser.go
@@ -239,9 +239,9 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 
 	log.Infoln("Finished parsing tests with quarantine list")
 
-	// if stats.FailCount > 0 || stats.ErrorCount > 0 {
-	// 	return stats, fmt.Errorf("found %d non-quarantined failed tests and %d errors", stats.FailCount, stats.ErrorCount)
-	// }
+	if stats.FailCount > 0 || stats.ErrorCount > 0 {
+		return stats, fmt.Errorf("found %d non-quarantined failed tests and %d errors", stats.FailCount, stats.ErrorCount)
+	}
 	return stats, nil
 }
 

--- a/parser.go
+++ b/parser.go
@@ -322,6 +322,7 @@ func isExpired(testIdentifier string, quarantineList map[string]interface{}, log
 						}
 
 						if currentDate.Before(startTime) || currentDate.After(endTime) {
+							log.Infoln(fmt.Sprintf("Current Date %s lies outside start_date %s and end_date %s.", currentDate, startTime, endTime))
 							return true
 						}
 					}

--- a/parser.go
+++ b/parser.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+	"strconv"
 
 	"github.com/harness-community/parse-test-reports/gojunit"
 	"github.com/mattn/go-zglob"
@@ -42,8 +42,7 @@ func ParseTests(paths []string, log *logrus.Logger) (TestStats, error) {
 	for _, file := range files {
 		suites, err := gojunit.IngestFile(file)
 		if err != nil {
-			log.WithError(err).WithField("file", file).
-				Errorln(fmt.Sprintf("could not parse file %s", file))
+			log.WithError(err).WithField("file", file).Errorln("could not parse file")
 			continue
 		}
 		fileStats := TestStats{}
@@ -62,9 +61,15 @@ func ParseTests(paths []string, log *logrus.Logger) (TestStats, error) {
 				}
 			}
 		}
-		log.Infoln(fmt.Sprintf("File %s processed. Stats: Total: %d, Passed: %d, Failed: %d, Skipped: %d, Errors: %d",
-			file, fileStats.TestCount, fileStats.PassCount, fileStats.FailCount, fileStats.SkippedCount, fileStats.ErrorCount))
-		
+		log.WithFields(logrus.Fields{
+			"file":    file,
+			"total":   fileStats.TestCount,
+			"passed":  fileStats.PassCount,
+			"failed":  fileStats.FailCount,
+			"skipped": fileStats.SkippedCount,
+			"errors":  fileStats.ErrorCount,
+		}).Infoln("File processed")
+
 		// Aggregate stats
 		stats.TestCount += fileStats.TestCount
 		stats.PassCount += fileStats.PassCount
@@ -74,25 +79,23 @@ func ParseTests(paths []string, log *logrus.Logger) (TestStats, error) {
 	}
 
 	if stats.FailCount > 0 || stats.ErrorCount > 0 {
-		return stats, fmt.Errorf("found %d failed tests and %d errors", stats.FailCount, stats.ErrorCount)
+		return stats, errors.New("failed tests and errors found")
 	}
 	return stats, nil
 }
 
-// getFiles returns uniques file paths provided in the input after expanding the input paths
+// getFiles returns unique file paths after expanding the input paths
 func getFiles(paths []string, log *logrus.Logger) []string {
 	var files []string
 	for _, p := range paths {
 		path, err := expandTilde(p)
 		if err != nil {
-			log.WithError(err).WithField("path", p).
-				Errorln("errored while trying to expand paths")
+			log.WithError(err).WithField("path", p).Errorln("error expanding path")
 			continue
 		}
 		matches, err := zglob.Glob(path)
 		if err != nil {
-			log.WithError(err).WithField("path", path).
-				Errorln("errored while trying to resolve path regex")
+			log.WithError(err).WithField("path", path).Errorln("error resolving path regex")
 			continue
 		}
 
@@ -103,10 +106,9 @@ func getFiles(paths []string, log *logrus.Logger) []string {
 
 func uniqueItems(items []string) []string {
 	var result []string
-
 	set := make(map[string]bool)
 	for _, item := range items {
-		if _, ok := set[item]; !ok {
+		if !set[item] {
 			result = append(result, item)
 			set[item] = true
 		}
@@ -114,79 +116,69 @@ func uniqueItems(items []string) []string {
 	return result
 }
 
-// expandTilde method expands the given file path to include the home directory
-// if the path is prefixed with `~`. If it isn't prefixed with `~`, the path is
-// returned as-is.
+// expandTilde expands the given path to include the home directory if prefixed with `~`.
 func expandTilde(path string) (string, error) {
 	if path == "" {
 		return path, nil
 	}
-
 	if path[0] != '~' {
 		return path, nil
 	}
-
 	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
 		return "", errors.New("cannot expand user-specific home dir")
 	}
-
 	dir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch home directory: %s", err)
+		return "", err
 	}
 	return filepath.Join(dir, path[1:]), nil
 }
 
-// LoadYAML reads a YAML file from either a public URL or a local file and returns the data as a map
+// LoadYAML reads a YAML file from either a URL or a local file
 func LoadYAML(source string) (map[string]interface{}, error) {
 	log := logrus.New()
-	log.Infoln(fmt.Sprintf("Loading YAML from source: %s", source))
+	log.Infoln("Loading YAML from source:", source)
 
 	var data []byte
 	var err error
 
-	// Check if source is a URL
 	if isURL(source) {
-		// Fetch the YAML content from the URL
 		resp, err := http.Get(source)
 		if err != nil {
 			log.WithError(err).Errorln("Failed to fetch YAML from URL")
-			return nil, fmt.Errorf("failed to fetch YAML from URL: %w", err)
+			return nil, err
 		}
 		defer resp.Body.Close()
 
 		data, err = io.ReadAll(resp.Body)
 		if err != nil {
 			log.WithError(err).Errorln("Failed to read YAML data from URL")
-			return nil, fmt.Errorf("failed to read YAML data from URL: %w", err)
+			return nil, err
 		}
 	} else {
-		// Read the YAML content from the local file
 		data, err = os.ReadFile(source)
 		if err != nil {
 			log.WithError(err).Errorln("Failed to read local YAML file")
-			return nil, fmt.Errorf("failed to read YAML file: %w", err)
+			return nil, err
 		}
 	}
 
-	// Parse YAML data
 	var result map[string]interface{}
 	err = yaml.Unmarshal(data, &result)
 	if err != nil {
 		log.WithError(err).Errorln("Failed to parse YAML")
-		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+		return nil, err
 	}
 
 	log.Infoln("Successfully loaded and parsed YAML")
 	return result, nil
 }
 
-// Helper function to check if the source is a URL
 func isURL(source string) bool {
-	return len(source) > 4 && source[:4] == "http"
+	return strings.HasPrefix(source, "http")
 }
 
-// ParseTestsWithQuarantine parses XMLs and fails only if errors are found in non-quarantined tests
+// ParseTestsWithQuarantine parses XMLs, considers quarantined tests, and returns errors if any non-quarantined failures are found
 func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interface{}, log *logrus.Logger) (TestStats, error) {
 	files := getFiles(paths, log)
 	stats := TestStats{}
@@ -203,45 +195,42 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 	for _, file := range files {
 		suites, err := gojunit.IngestFile(file)
 		if err != nil {
-			log.WithError(err).WithField("file", file).
-				Errorln(fmt.Sprintf("could not parse file %s", file))
+			log.WithError(err).WithField("file", file).Errorln("could not parse file")
 			continue
 		}
 		fileStats := TestStats{}
 		for _, suite := range suites {
 			for _, test := range suite.Tests {
 				fileStats.TestCount++
-				testIdentifier := fmt.Sprintf("%s.%s", test.Classname, test.Name)
+				testIdentifier := test.Classname + "." + test.Name
 				switch test.Result.Status {
 				case "passed":
 					fileStats.PassCount++
 				case "failed":
-					// Check if the test is quarantined
 					if !isQuarantined(testIdentifier, quarantineList, log) {
-						log.Infoln(fmt.Sprintf("Not Quarantined test failed: %s", testIdentifier))
+						log.Infoln("Not Quarantined test failed:", testIdentifier)
 						nonQuarantinedFailures++
-					} else {
-						log.Infoln(fmt.Sprintf("Quarantined test failed: %s", testIdentifier))
-
-						// Check if the test is expired
-						if isExpired(testIdentifier, quarantineList, log) {
-							log.Infoln(fmt.Sprintf("Quarantined test expired: %s", testIdentifier))
-							expiredTests++
-						}
+					} else if isExpired(testIdentifier, quarantineList, log) {
+						log.Infoln("Quarantined test expired:", testIdentifier)
+						expiredTests++
 					}
 					fileStats.FailCount++
 				case "skipped":
 					fileStats.SkippedCount++
 				case "error":
 					fileStats.ErrorCount++
-					// nonQuarantinedFailures++ // Assuming errors are always considered non-quarantined
 				}
 			}
 		}
-		log.Infoln(fmt.Sprintf("File %s processed. Stats: Total: %d, Passed: %d, Failed: %d, Skipped: %d, Errors: %d",
-			file, fileStats.TestCount, fileStats.PassCount, fileStats.FailCount, fileStats.SkippedCount, fileStats.ErrorCount))
-		
-		// Aggregate stats
+		log.WithFields(logrus.Fields{
+			"file":    file,
+			"total":   fileStats.TestCount,
+			"passed":  fileStats.PassCount,
+			"failed":  fileStats.FailCount,
+			"skipped": fileStats.SkippedCount,
+			"errors":  fileStats.ErrorCount,
+		}).Infoln("File processed")
+
 		stats.TestCount += fileStats.TestCount
 		stats.PassCount += fileStats.PassCount
 		stats.FailCount += fileStats.FailCount
@@ -249,87 +238,90 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 		stats.ErrorCount += fileStats.ErrorCount
 	}
 
-	log.Infoln("Finished parsing tests with quarantine list")
-
 	if nonQuarantinedFailures > 0 || expiredTests > 0 {
-		return stats, fmt.Errorf("found %d non-quarantined failed tests and %d expired tests", nonQuarantinedFailures, expiredTests)
+		// Construct the error message by concatenating string values
+		errorMessage := "Non-quarantined failures: " + strconv.Itoa(nonQuarantinedFailures) + 
+			", Expired tests: " + strconv.Itoa(expiredTests) + " found"
+		return stats, errors.New(errorMessage)
 	}
+	
 	return stats, nil
 }
 
-// isQuarantined checks if the test is present in the quarantine list and respects the date range
 func isQuarantined(testIdentifier string, quarantineList map[string]interface{}, log *logrus.Logger) bool {
-	log.Infoln(fmt.Sprintf("Checking if test is quarantined: %s", testIdentifier))
-
+	log.Infoln("Checking if test is quarantined:", testIdentifier)
 	tests, ok := quarantineList["quarantine_tests"].([]interface{})
 	if !ok {
-		log.Warnln("Quarantine list does not contain 'quarantine_tests' key or it's not a slice")
+		log.Warnln("Quarantine list invalid or missing 'quarantine_tests'")
 		return false
 	}
-
 	for _, test := range tests {
 		if testMap, ok := test.(map[interface{}]interface{}); ok {
-			quarantinedClassname, classnameOk := testMap["classname"].(string)
-			quarantinedName, nameOk := testMap["name"].(string)
-
-			if classnameOk && nameOk {
-				quarantinedIdentifier := quarantinedClassname + "." + quarantinedName
-				if quarantinedIdentifier == testIdentifier {
-					log.Infoln(fmt.Sprintf("Test %s is quarantined", testIdentifier))
-					return true
-				}
+			if quarantinedIdentifier, found := matchTestIdentifier(testMap, testIdentifier, log); found {
+				log.Infoln("Test is quarantined:", quarantinedIdentifier)
+				return true
 			}
 		}
 	}
-
-	log.Infoln(fmt.Sprintf("Test %s is not quarantined", testIdentifier))
+	log.Infoln("Test is not quarantined:", testIdentifier)
 	return false
 }
 
-// isExpired checks if the current date is outside the start_date and end_date for a quarantined test
 func isExpired(testIdentifier string, quarantineList map[string]interface{}, log *logrus.Logger) bool {
 	tests, ok := quarantineList["quarantine_tests"].([]interface{})
 	if !ok {
-		log.Warnln("Quarantine list does not contain 'quarantine_tests' key or it's not a slice")
+		log.Warnln("Quarantine list invalid or missing 'quarantine_tests'")
 		return false
 	}
-
 	for _, test := range tests {
 		if testMap, ok := test.(map[interface{}]interface{}); ok {
-			quarantinedClassname, classnameOk := testMap["classname"].(string)
-			quarantinedName, nameOk := testMap["name"].(string)
+			if quarantinedIdentifier, found := matchTestIdentifier(testMap, testIdentifier, log); found {
+				startDate, startOk := testMap["start_date"].(string)
+				endDate, endOk := testMap["end_date"].(string)
 
-			if classnameOk && nameOk {
-				quarantinedIdentifier := quarantinedClassname + "." + quarantinedName
-				if quarantinedIdentifier == testIdentifier {
-					// Check for date range
-					startDate, startOk := testMap["start_date"].(string)
-					endDate, endOk := testMap["end_date"].(string)
+				if startOk && endOk {
+					currentDate := time.Now()
 
-					if startOk && endOk {
-						currentDate := time.Now()
+					startTime, err := time.Parse("2006-01-02", startDate)
+					if err != nil {
+						log.WithError(err).Warnln("Failed to parse start_date")
+						continue
+					}
 
-						startTime, err := time.Parse("2006-01-02", startDate)
-						if err != nil {
-							log.WithError(err).Warnln("Failed to parse start_date")
-							continue
-						}
+					endTime, err := time.Parse("2006-01-02", endDate)
+					if err != nil {
+						log.WithError(err).Warnln("Failed to parse end_date")
+						continue
+					}
 
-						endTime, err := time.Parse("2006-01-02", endDate)
-						if err != nil {
-							log.WithError(err).Warnln("Failed to parse end_date")
-							continue
-						}
-
-						if currentDate.Before(startTime) || currentDate.After(endTime) {
-							log.Infoln(fmt.Sprintf("Current Date %s lies outside start_date %s and end_date %s.", currentDate, startTime, endTime))
-							return true
-						}
+					if currentDate.Before(startTime) || currentDate.After(endTime) {
+						log.WithFields(logrus.Fields{
+							"test":        quarantinedIdentifier,
+							"currentDate": currentDate,
+							"startDate":   startTime,
+							"endDate":     endTime,
+						}).Infoln("Current Date lies outside start_date and end_date.")
+						return true
 					}
 				}
 			}
 		}
 	}
 
+	log.Infoln("Test has no expiration set:", testIdentifier)
 	return false
+}
+
+func matchTestIdentifier(testMap map[interface{}]interface{}, identifier string, log *logrus.Logger) (string, bool) {
+	quarantinedClassname, classnameOk := testMap["classname"].(string)
+	quarantinedName, nameOk := testMap["name"].(string)
+
+	if classnameOk && nameOk {
+		quarantinedIdentifier := quarantinedClassname + "." + quarantinedName
+		if quarantinedIdentifier == identifier {
+			log.Infoln("Test", identifier, "is quarantined")
+			return quarantinedIdentifier, true
+		}
+	}
+	return "", false
 }

--- a/plugin.go
+++ b/plugin.go
@@ -72,11 +72,11 @@ func (p Plugin) Exec() error {
 
 func writeTestStats(stats TestStats, log *logrus.Logger) {
 	statsMap := map[string]int{
-		"TEST_COUNT":  stats.TestCount,
-		"FAIL_COUNT":  stats.FailCount,
-		"PASS_COUNT":  stats.PassCount,
-		"SKIPPED":     stats.SkippedCount,
-		"ERROR_COUNT": stats.ErrorCount,
+		"TOTAL_TESTS":  stats.TestCount,
+		"FAILED_TESTS":  stats.FailCount,
+		"PASSED_TESTS":  stats.PassCount,
+		"SKIPPED_TESTS":     stats.SkippedCount,
+		"ERROR_TESTS": stats.ErrorCount,
 	}
 
 	for key, value := range statsMap {

--- a/plugin.go
+++ b/plugin.go
@@ -3,12 +3,23 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 )
 
 type Plugin struct {
-	GlobPaths string
+	GlobPaths        string
+	QuarantineFile   string
+	FailOnQuarantine bool
+}
+
+type TestStats struct {
+	TestCount   int
+	FailCount   int
+	PassCount   int
+	SkippedCount int
+	ErrorCount  int
 }
 
 // Exec executes the plugin.
@@ -23,9 +34,67 @@ func (p Plugin) Exec() error {
 
 	paths := getPaths(p.GlobPaths)
 	log.Infoln(fmt.Sprintf("Parsing test cases in globs: %s", paths))
-	if err := ParseTests(paths, log); err != nil {
-		log.Errorln(fmt.Sprintf("Error while parsing tests: %s", err))
-		os.Exit(1)
+
+	var stats TestStats
+
+	if p.FailOnQuarantine {
+		if p.QuarantineFile == "" {
+			log.Errorln(fmt.Errorf("fail_on_quarantine is true, but %s plugin setting or %s environment variable is not set", quarantineFileSetting, quarantineFileEnv))
+			os.Exit(1)
+		}
+
+		quarantineList, err := LoadYAML(p.QuarantineFile)
+		if err != nil {
+			log.Errorln(fmt.Sprintf("Error loading quarantine file: %s", err))
+			os.Exit(1)
+		}
+
+		stats, err = ParseTestsWithQuarantine(paths, quarantineList, log)
+		if err != nil {
+			log.Errorln(fmt.Sprintf("Error while parsing tests: %s", err))
+			os.Exit(1)
+		}
+	} else {
+		var err error
+		stats, err = ParseTests(paths, log)
+		if err != nil {
+			log.Errorln(fmt.Sprintf("Error while parsing tests: %s", err))
+			os.Exit(1)
+		}
+	}
+
+	// Write output variables
+	if err := WriteEnvToFile("TEST_COUNT", strconv.Itoa(stats.TestCount)); err != nil {
+		log.Errorln(fmt.Sprintf("Error writing TEST_COUNT: %s", err))
+	}
+	if err := WriteEnvToFile("FAIL_COUNT", strconv.Itoa(stats.FailCount)); err != nil {
+		log.Errorln(fmt.Sprintf("Error writing FAIL_COUNT: %s", err))
+	}
+	if err := WriteEnvToFile("PASS_COUNT", strconv.Itoa(stats.PassCount)); err != nil {
+		log.Errorln(fmt.Sprintf("Error writing PASS_COUNT: %s", err))
+	}
+	if err := WriteEnvToFile("SKIPPED", strconv.Itoa(stats.SkippedCount)); err != nil {
+		log.Errorln(fmt.Sprintf("Error writing SKIPPED: %s", err))
+	}
+	if err := WriteEnvToFile("ERROR_COUNT", strconv.Itoa(stats.ErrorCount)); err != nil {
+		log.Errorln(fmt.Sprintf("Error writing ERROR_COUNT: %s", err))
+	}
+
+	log.Infoln(fmt.Sprintf("Final test statistics: Total: %d, Passed: %d, Failed: %d, Skipped: %d, Errors: %d",
+		stats.TestCount, stats.PassCount, stats.FailCount, stats.SkippedCount, stats.ErrorCount))
+
+	return nil
+}
+
+func WriteEnvToFile(key, value string) error {
+	outputFile, err := os.OpenFile(os.Getenv("DRONE_OUTPUT"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open output file: %w", err)
+	}
+	defer outputFile.Close()
+	_, err = fmt.Fprintf(outputFile, "%s=%s\n", key, value)
+	if err != nil {
+		return fmt.Errorf("failed to write to env: %w", err)
 	}
 	return nil
 }

--- a/plugin.go
+++ b/plugin.go
@@ -36,6 +36,7 @@ func (p Plugin) Exec() error {
 	log.Infoln(fmt.Sprintf("Parsing test cases in globs: %s", paths))
 
 	var stats TestStats
+	var err error
 
 	if p.FailOnQuarantine {
 		if p.QuarantineFile == "" {
@@ -43,55 +44,56 @@ func (p Plugin) Exec() error {
 			os.Exit(1)
 		}
 
-		quarantineList, err := LoadYAML(p.QuarantineFile)
-		if err != nil {
-			log.Errorln(fmt.Sprintf("Error loading quarantine file: %s", err))
+		quarantineList, loadErr := LoadYAML(p.QuarantineFile)
+		if loadErr != nil {
+			log.Errorln(fmt.Sprintf("Error loading quarantine file: %s", loadErr))
 			os.Exit(1)
 		}
 
 		stats, err = ParseTestsWithQuarantine(paths, quarantineList, log)
-		if err != nil {
-			log.Errorln(fmt.Sprintf("Error while parsing tests: %s", err))
-			os.Exit(1)
-		}
 	} else {
-		var err error
 		stats, err = ParseTests(paths, log)
-		if err != nil {
-			log.Errorln(fmt.Sprintf("Error while parsing tests: %s", err))
-			os.Exit(1)
-		}
 	}
 
-	// Write output variables
-	if err := WriteEnvToFile("TEST_COUNT", strconv.Itoa(stats.TestCount)); err != nil {
-		log.Errorln(fmt.Sprintf("Error writing TEST_COUNT: %s", err))
-	}
-	if err := WriteEnvToFile("FAIL_COUNT", strconv.Itoa(stats.FailCount)); err != nil {
-		log.Errorln(fmt.Sprintf("Error writing FAIL_COUNT: %s", err))
-	}
-	if err := WriteEnvToFile("PASS_COUNT", strconv.Itoa(stats.PassCount)); err != nil {
-		log.Errorln(fmt.Sprintf("Error writing PASS_COUNT: %s", err))
-	}
-	if err := WriteEnvToFile("SKIPPED", strconv.Itoa(stats.SkippedCount)); err != nil {
-		log.Errorln(fmt.Sprintf("Error writing SKIPPED: %s", err))
-	}
-	if err := WriteEnvToFile("ERROR_COUNT", strconv.Itoa(stats.ErrorCount)); err != nil {
-		log.Errorln(fmt.Sprintf("Error writing ERROR_COUNT: %s", err))
-	}
+	// Always write output variables, even if there was an error
+	writeTestStats(stats, log)
 
 	log.Infoln(fmt.Sprintf("Final test statistics: Total: %d, Passed: %d, Failed: %d, Skipped: %d, Errors: %d",
 		stats.TestCount, stats.PassCount, stats.FailCount, stats.SkippedCount, stats.ErrorCount))
 
+	// Handle the error after writing stats
+	if err != nil {
+		log.Errorln(fmt.Sprintf("Error while parsing tests: %s", err))
+		os.Exit(1)
+	}
+
 	return nil
 }
 
-func WriteEnvToFile(key, value string) error {
+func writeTestStats(stats TestStats, log *logrus.Logger) {
+	statsMap := map[string]int{
+		"TEST_COUNT":  stats.TestCount,
+		"FAIL_COUNT":  stats.FailCount,
+		"PASS_COUNT":  stats.PassCount,
+		"SKIPPED":     stats.SkippedCount,
+		"ERROR_COUNT": stats.ErrorCount,
+	}
+
+	for key, value := range statsMap {
+		if err := WriteEnvToFile(key, strconv.Itoa(value), log); err != nil {
+			log.Errorln(fmt.Sprintf("Error writing %s: %s", key, err))
+		}
+	}
+}
+
+
+func WriteEnvToFile(key, value string, log *logrus.Logger) error {
 	outputFile, err := os.OpenFile(os.Getenv("DRONE_OUTPUT"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to open output file: %w", err)
 	}
 	defer outputFile.Close()
+	log.Infoln(fmt.Sprintf("Writing Test Stats %s : %s in func WriteEnvToFile to DRONE_OUTPUT",key,value))
 	_, err = fmt.Fprintf(outputFile, "%s=%s\n", key, value)
 	if err != nil {
 		return fmt.Errorf("failed to write to env: %w", err)

--- a/quarantinelist.yaml
+++ b/quarantinelist.yaml
@@ -1,0 +1,11 @@
+quarantine_tests:
+  - classname: name2
+    name: TestOne
+    start_date:
+    end_date:
+    meta:
+  - classname: JUnitXmlReporter.constructor
+    name: should default path to an empty string
+    start_date:
+    end_date:
+    meta:

--- a/quarantinelist.yaml
+++ b/quarantinelist.yaml
@@ -9,3 +9,63 @@ quarantine_tests:
     start_date:
     end_date:
     meta:
+  - classname: pkg1.test.test_things
+    name: test_params_func:2
+    start_date:
+    end_date:
+    meta: Assertion failure
+  - classname: pkg1.test.test_things
+    name: test_params_func_multi_arg:2
+    start_date:
+    end_date:
+    meta: Assertion failure
+  - classname: pkg1.test.test_things.SomeTests
+    name: test_failed
+    start_date:
+    end_date:
+    meta: Assertion failure - "I failed"
+  - classname: pkg1.test.test_things.SomeTests
+    name: test_params_method:2
+    start_date:
+    end_date:
+    meta: Assertion failure - 2 != 1
+  - classname: pkg1.test.test_things.SomeTests
+    name: test_typeerr
+    start_date:
+    end_date:
+    meta: TypeError - "oops"
+  - classname: pkg1.test.test_things.SomeTests
+    name: test_gen_method:2
+    start_date:
+    end_date:
+    meta: Assertion failure
+  - classname: TestClassSample
+    name: testSomething()
+    start_date:
+    end_date:
+    meta: XCTAssertTrue failed
+  - classname: TestClassSample
+    name: testSomething2()
+    start_date:
+    end_date:
+    meta: NullPointerException
+  - classname: SampleTest
+    name: testB with data set "bool"
+    start_date:
+    end_date:
+    meta: ExpectationFailedException - False should be true
+  - classname: SampleTest
+    name: testC with data set #1
+    start_date:
+    end_date:
+    meta: ExpectationFailedException - 0 should be true
+  - classname: SampleTest
+    name: testC with data set #2
+    start_date:
+    end_date:
+    meta: ExpectationFailedException - '' should be true
+  - classname: com.example.FooTest
+    name: testStdoutStderr
+    start_date:
+    end_date:
+    meta: AssertionError

--- a/quarantinelist.yaml
+++ b/quarantinelist.yaml
@@ -7,7 +7,7 @@ quarantine_tests:
   - classname: JUnitXmlReporter.constructor
     name: should default path to an empty string
     start_date: 2023-05-01
-    end_date: 2023-11-30
+    end_date: 2025-11-30
     meta:
   - classname: pkg1.test.test_things
     name: test_params_func:2

--- a/quarantinelist.yaml
+++ b/quarantinelist.yaml
@@ -1,71 +1,71 @@
 quarantine_tests:
   - classname: name2
     name: TestOne
-    start_date:
-    end_date:
+    start_date: "2024-01-01"
+    end_date: "2025-12-31"
     meta:
   - classname: JUnitXmlReporter.constructor
     name: should default path to an empty string
-    start_date:
-    end_date:
+    start_date: "2023-05-01"
+    end_date: "2023-11-30"
     meta:
   - classname: pkg1.test.test_things
     name: test_params_func:2
-    start_date:
-    end_date:
+    start_date: "2023-10-01"
+    end_date: "2025-03-31"
     meta: Assertion failure
   - classname: pkg1.test.test_things
     name: test_params_func_multi_arg:2
-    start_date:
-    end_date:
+    start_date: "2024-01-15"
+    end_date: "2025-06-15"
     meta: Assertion failure
   - classname: pkg1.test.test_things.SomeTests
     name: test_failed
-    start_date:
-    end_date:
+    start_date: "2023-12-01"
+    end_date: "2025-02-01"
     meta: Assertion failure - "I failed"
   - classname: pkg1.test.test_things.SomeTests
     name: test_params_method:2
-    start_date:
-    end_date:
+    start_date: "2024-03-01"
+    end_date: "2025-07-01"
     meta: Assertion failure - 2 != 1
   - classname: pkg1.test.test_things.SomeTests
     name: test_typeerr
-    start_date:
-    end_date:
+    start_date: "2023-11-01"
+    end_date: "2023-12-31"
     meta: TypeError - "oops"
   - classname: pkg1.test.test_things.SomeTests
     name: test_gen_method:2
-    start_date:
-    end_date:
+    start_date: "2024-02-01"
+    end_date: "2025-08-31"
     meta: Assertion failure
   - classname: TestClassSample
     name: testSomething()
-    start_date:
-    end_date:
+    start_date: "2023-07-15"
+    end_date: "2025-01-15"
     meta: XCTAssertTrue failed
   - classname: TestClassSample
     name: testSomething2()
-    start_date:
-    end_date:
+    start_date: "2023-09-01"
+    end_date: "2025-03-31"
     meta: NullPointerException
   - classname: SampleTest
     name: testB with data set "bool"
-    start_date:
-    end_date:
+    start_date: "2024-04-01"
+    end_date: "2025-10-01"
     meta: ExpectationFailedException - False should be true
   - classname: SampleTest
     name: testC with data set #1
-    start_date:
-    end_date:
+    start_date: "2024-05-01"
+    end_date: "2025-12-01"
     meta: ExpectationFailedException - 0 should be true
   - classname: SampleTest
     name: testC with data set #2
-    start_date:
-    end_date:
+    start_date: "2023-08-01"
+    end_date: "2025-01-31"
     meta: ExpectationFailedException - '' should be true
   - classname: com.example.FooTest
     name: testStdoutStderr
-    start_date:
-    end_date:
+    start_date: "2023-09-15"
+    end_date: "2025-05-15"
     meta: AssertionError

--- a/quarantinelist.yaml
+++ b/quarantinelist.yaml
@@ -1,71 +1,71 @@
 quarantine_tests:
   - classname: name2
     name: TestOne
-    start_date: "2024-01-01"
-    end_date: "2025-12-31"
+    start_date: 2024-01-01
+    end_date: 2025-12-31
     meta:
   - classname: JUnitXmlReporter.constructor
     name: should default path to an empty string
-    start_date: "2023-05-01"
-    end_date: "2023-11-30"
+    start_date: 2023-05-01
+    end_date: 2023-11-30
     meta:
   - classname: pkg1.test.test_things
     name: test_params_func:2
-    start_date: "2023-10-01"
-    end_date: "2025-03-31"
+    start_date: 2023-10-01
+    end_date: 2025-03-31
     meta: Assertion failure
   - classname: pkg1.test.test_things
     name: test_params_func_multi_arg:2
-    start_date: "2024-01-15"
-    end_date: "2025-06-15"
+    start_date: 2024-01-15
+    end_date: 2025-06-15
     meta: Assertion failure
   - classname: pkg1.test.test_things.SomeTests
     name: test_failed
-    start_date: "2023-12-01"
-    end_date: "2025-02-01"
-    meta: Assertion failure - "I failed"
+    start_date: 2023-12-01
+    end_date: 2025-02-01
+    meta: Assertion failure - I failed
   - classname: pkg1.test.test_things.SomeTests
     name: test_params_method:2
-    start_date: "2024-03-01"
-    end_date: "2025-07-01"
+    start_date: 2024-03-01
+    end_date: 2025-07-01
     meta: Assertion failure - 2 != 1
   - classname: pkg1.test.test_things.SomeTests
     name: test_typeerr
-    start_date: "2023-11-01"
-    end_date: "2023-12-31"
-    meta: TypeError - "oops"
+    start_date: 2023-11-01
+    end_date: 2023-12-31
+    meta: TypeError - oops
   - classname: pkg1.test.test_things.SomeTests
     name: test_gen_method:2
-    start_date: "2024-02-01"
-    end_date: "2025-08-31"
+    start_date: 2024-02-01
+    end_date: 2025-08-31
     meta: Assertion failure
   - classname: TestClassSample
     name: testSomething()
-    start_date: "2023-07-15"
-    end_date: "2025-01-15"
+    start_date: 2023-07-15
+    end_date: 2025-01-15
     meta: XCTAssertTrue failed
   - classname: TestClassSample
     name: testSomething2()
-    start_date: "2023-09-01"
-    end_date: "2025-03-31"
+    start_date: 2023-09-01
+    end_date: 2025-03-31
     meta: NullPointerException
   - classname: SampleTest
     name: testB with data set "bool"
-    start_date: "2024-04-01"
-    end_date: "2025-10-01"
+    start_date: 2024-04-01
+    end_date: 2025-10-01
     meta: ExpectationFailedException - False should be true
   - classname: SampleTest
     name: testC with data set #1
-    start_date: "2024-05-01"
-    end_date: "2025-12-01"
+    start_date: 2024-05-01
+    end_date: 2025-12-01
     meta: ExpectationFailedException - 0 should be true
   - classname: SampleTest
     name: testC with data set #2
-    start_date: "2023-08-01"
-    end_date: "2025-01-31"
+    start_date: 2023-08-01
+    end_date: 2025-01-31
     meta: ExpectationFailedException - '' should be true
   - classname: com.example.FooTest
     name: testStdoutStderr
-    start_date: "2023-09-15"
-    end_date: "2025-05-15"
+    start_date: 2023-09-15
+    end_date: 2025-05-15
     meta: AssertionError

--- a/quarantinelist.yaml
+++ b/quarantinelist.yaml
@@ -31,8 +31,8 @@ quarantine_tests:
     meta: Assertion failure - 2 != 1
   - classname: pkg1.test.test_things.SomeTests
     name: test_typeerr
-    start_date: 2023-11-01
-    end_date: 2023-12-31
+    start_date:
+    end_date:
     meta: TypeError - oops
   - classname: pkg1.test.test_things.SomeTests
     name: test_gen_method:2
@@ -66,6 +66,6 @@ quarantine_tests:
     meta: ExpectationFailedException - '' should be true
   - classname: com.example.FooTest
     name: testStdoutStderr
-    start_date: 2023-09-15
-    end_date: 2025-05-15
+    start_date:
+    end_date:
     meta: AssertionError


### PR DESCRIPTION
### Added New Settings: `quarantine_file` and `fail_on_quarantine`

- **New Parameters:**
  - `quarantine_file`: Accepts a file that contains quarantined tests.
  - `fail_on_quarantine`: A boolean flag to indicate whether the pipeline should fail based on the quarantine status.

- **Behavior Changes:**
  - Previously, the function would throw an error if any tests failed, causing the pipeline to exit. 
  - Now, if `fail_on_quarantine` is set to `true` and a `quarantine_file` is provided, the pipeline does **not** fail if the tests are present in the quarantined tests. Instead, it continues running, ensuring the outputs are calculated without errors.
  - The pipeline fails if `fail_on_quarantine` is `true` and the `quarantine_file` is **not** provided.

### Added Output Variables

- Output variables are now available in the plugin step to provide aggregated results for the test files matching the `test_globs` pattern.

### Logs Added

- Logs to check if the tests are quarantined or not.
- Logs to provide output variables for each `.xml` file parsed.
