### PR TITLE
Throw an error if no test report passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Below is the example with ‘fail_on_quarantine’ = true
                     image: plugins/test-analysis:latest
                     settings:
                       test_globs: sample1/*.xml, sample2/*.xml
-                      quarantine_file: quarantinelist.yaml 
+                      quarantine_file: quarantinelist.yaml
                       fail_on_quarantine: true
               - step:
                   identifier: verify_output_variables

--- a/parser.go
+++ b/parser.go
@@ -36,7 +36,7 @@ func ParseTests(paths []string, log *logrus.Logger) (TestStats, error) {
 
 	if len(files) == 0 {
 		log.Errorln("could not find any files matching the provided report path")
-		return stats, nil
+		return stats, errors.New("could not find any files matching the provided report path")
 	}
 
 	for _, file := range files {
@@ -187,7 +187,7 @@ func ParseTestsWithQuarantine(paths []string, quarantineList map[string]interfac
 
 	if len(files) == 0 {
 		log.Errorln("could not find any files matching the provided report path")
-		return stats, nil
+		return stats, errors.New("could not find any files matching the provided report path")
 	}
 
 	log.Infoln("Starting to parse tests with quarantine list")


### PR DESCRIPTION
Since we mark the test step with "Failures ignored" we're relying on this plugin to parse the test report. But if there is no test report to parse - it should raise an error. Otherwise it could hide a case when tests didn't launch or failed in some nasty way that test framework couldn't produce a proper test report. 